### PR TITLE
Use PHPUnit 7 only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5 | ^7.0",
+        "phpunit/phpunit": "^7.0",
         "phpstan/phpstan": "^0.9.1"
     },
     "license": "MIT",


### PR DESCRIPTION
As we minimum require `PHP 7.1`, we can safely use PHPUnit 7 only here :)