### PR TITLE
Enable PHPStan in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - travis_retry composer install --prefer-source --no-interaction --dev
 script:
   - vendor/bin/phpunit
-  - vendor/bin/phpstan analyse src --level 7
+  - vendor/bin/phpstan analyse src tests --level max


### PR DESCRIPTION
I've also used `--level max`, so we can ensure we're always using the maximum level at PHPStan :+1: 